### PR TITLE
fix: create .vscode directory if doesnt exist

### DIFF
--- a/src/command/GenerateXmlCatalogCommand.ts
+++ b/src/command/GenerateXmlCatalogCommand.ts
@@ -26,7 +26,12 @@ export default class GenerateXmlCatalogCommand extends Command {
       return;
     }
 
-    const catalogLocation = Uri.joinPath(workspaceFolder.uri, '.vscode/magento-catalog.xml');
+    const vscodeDirectory = Uri.joinPath(workspaceFolder.uri, '.vscode');
+    const catalogLocation = Uri.joinPath(vscodeDirectory, 'magento-catalog.xml');
+
+    if (!(await FileSystem.fileExists(vscodeDirectory))) {
+      await FileSystem.createDirectory(vscodeDirectory);
+    }
 
     if (await FileSystem.fileExists(catalogLocation)) {
       await FileSystem.deleteFile(catalogLocation);

--- a/src/util/FileSystem.ts
+++ b/src/util/FileSystem.ts
@@ -34,6 +34,10 @@ export default class FileSystem {
     await workspace.fs.writeFile(uri, Buffer.from(content));
   }
 
+  public static async createDirectory(uri: Uri): Promise<void> {
+    await workspace.fs.createDirectory(uri);
+  }
+
   public static async deleteFile(
     uri: Uri,
     options: { recursive: boolean } = { recursive: false }


### PR DESCRIPTION
Schema generation fails if .vscode directory does not exist